### PR TITLE
[fix bug] keep the most recent 10000 webhook requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ app.post('/webhooks', function (req, res) {
   console.log(JSON.stringify(req.body, null, 2));
   received_updates.unshift(req.body);
   // take the last 10k entries
-  received_updates = received_updates.slice(-10000);
+  received_updates = received_updates.slice(0, 10000);
   res.sendStatus(200);
 });
 


### PR DESCRIPTION
because `unshift` will add entries to the start of the array, we want to slice the first 10,000 of them instead of the last 10,000